### PR TITLE
Add ContainerPatcher for patching DI services in tests

### DIFF
--- a/.docs/README.md
+++ b/.docs/README.md
@@ -53,6 +53,33 @@ Environment::setupFunctions();
 
 ### Utils
 
+#### ContainerPatcher
+
+Util class for replacing existing services in compiled Nette DI containers.
+
+```php
+use Contributte\Tester\Utils\ContainerPatcher;
+use Nette\DI\Container;
+
+ContainerPatcher::of($container)
+	// replace one service by name
+	->service('http.client', fn (Container $container): object => new FakeHttpClient())
+	// replace all services by type (closure can receive service name)
+	->type(App\Contracts\Clock::class, fn (Container $container, string $name): object => new FrozenClock())
+	// replace all services tagged by a custom tag
+	->tag('app.transport', fn (): object => new InMemoryTransport())
+	// patch by pre-built service instance
+	->serviceInstance('http.client', new FakeHttpClient());
+```
+
+Available methods:
+
+- `ContainerPatcher::of($container)` creates patcher for given container.
+- `->service('name', $factory)` patches service by service name.
+- `->type(SomeClass::class, $factory)` patches all services matching type.
+- `->tag('tag.name', $factory)` patches all services with given tag.
+- `->serviceInstance()`, `->typeInstance()`, `->tagInstance()` patch by pre-built object instance.
+
 #### Notes
 
 Util class for capturing messages. Useful for callback testing.

--- a/src/Utils/ContainerPatcher.php
+++ b/src/Utils/ContainerPatcher.php
@@ -1,0 +1,136 @@
+<?php declare(strict_types = 1);
+
+namespace Contributte\Tester\Utils;
+
+use Closure;
+use Nette\DI\Container;
+use Nette\DI\MissingServiceException;
+use ReflectionFunction;
+
+final class ContainerPatcher
+{
+
+	private function __construct(
+		private Container $container,
+	)
+	{
+	}
+
+	public static function of(Container $container): self
+	{
+		return new self($container);
+	}
+
+	/**
+	 * @param Closure(Container): object|Closure(Container, string): object $factory
+	 */
+	public function service(string $name, Closure $factory): self
+	{
+		if (!$this->container->hasService($name)) {
+			throw new MissingServiceException(sprintf('Service named "%s" not found in container.', $name));
+		}
+
+		return $this->replace([$name], $factory);
+	}
+
+	public function serviceInstance(string $name, object $service): self
+	{
+		if (!$this->container->hasService($name)) {
+			throw new MissingServiceException(sprintf('Service named "%s" not found in container.', $name));
+		}
+
+		$this->container->removeService($name);
+		$this->container->addService($name, $service);
+
+		return $this;
+	}
+
+	/**
+	 * @template T of object
+	 * @param class-string<T> $type
+	 * @param Closure(Container): T|Closure(Container, string): T $factory
+	 */
+	public function type(string $type, Closure $factory): self
+	{
+		$names = $this->container->findByType($type);
+
+		if ($names === []) {
+			throw new MissingServiceException(sprintf('Service of type "%s" not found in container.', $type));
+		}
+
+		return $this->replace($names, $factory);
+	}
+
+	public function typeInstance(string $type, object $service): self
+	{
+		$names = $this->container->findByType($type);
+
+		if ($names === []) {
+			throw new MissingServiceException(sprintf('Service of type "%s" not found in container.', $type));
+		}
+
+		foreach ($names as $name) {
+			$this->container->removeService($name);
+			$this->container->addService($name, $service);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * @param Closure(Container): object|Closure(Container, string): object $factory
+	 */
+	public function tag(string $tag, Closure $factory): self
+	{
+		$services = $this->container->findByTag($tag);
+
+		if ($services === []) {
+			throw new MissingServiceException(sprintf('Service tagged "%s" not found in container.', $tag));
+		}
+
+		return $this->replace(array_keys($services), $factory);
+	}
+
+	public function tagInstance(string $tag, object $service): self
+	{
+		$services = $this->container->findByTag($tag);
+
+		if ($services === []) {
+			throw new MissingServiceException(sprintf('Service tagged "%s" not found in container.', $tag));
+		}
+
+		foreach (array_keys($services) as $name) {
+			$this->container->removeService($name);
+			$this->container->addService($name, $service);
+		}
+
+		return $this;
+	}
+
+	/**
+	 * @param array<string> $names
+	 * @param Closure(Container): object|Closure(Container, string): object $factory
+	 */
+	private function replace(array $names, Closure $factory): self
+	{
+		foreach ($names as $name) {
+			$service = $this->createService($factory, $name);
+			$this->container->removeService($name);
+			$this->container->addService($name, $service);
+		}
+
+		return $this;
+	}
+
+	private function createService(Closure $factory, string $name): object
+	{
+		$reflection = new ReflectionFunction($factory);
+
+		if ($reflection->getNumberOfParameters() < 2) {
+			return $factory($this->container);
+		}
+
+		return $factory($this->container, $name);
+	}
+
+}

--- a/tests/Cases/ContainerPatcher.phpt
+++ b/tests/Cases/ContainerPatcher.phpt
@@ -1,0 +1,79 @@
+<?php declare(strict_types = 1);
+
+use Contributte\Tester\Utils\ContainerBuilder;
+use Contributte\Tester\Utils\ContainerPatcher;
+use Contributte\Tester\Utils\Notes;
+use Nette\DI\Compiler;
+use Nette\DI\Container;
+use Nette\DI\MissingServiceException;
+use Tester\Assert;
+
+require_once __DIR__ . '/../bootstrap.php';
+
+$container = ContainerBuilder::of(__FILE__)
+	->withCompiler(function (Compiler $compiler): void {
+		$compiler->addConfig([
+			'services' => [
+				'named' => ['create' => ArrayObject::class],
+				'type.a' => ['create' => DateTimeImmutable::class],
+				'type.b' => ['create' => DateTimeImmutable::class],
+				'tag.one' => ['create' => stdClass::class, 'tags' => ['demo.tag' => true]],
+				'tag.two' => ['create' => stdClass::class, 'tags' => ['demo.tag' => ['scope' => 'all']]],
+			],
+		]);
+	})
+	->build();
+
+ContainerPatcher::of($container)->service('named', function (Container $passedContainer) use ($container): object {
+	Assert::same($container, $passedContainer);
+	Notes::add('service:named');
+
+	return new ArrayObject(['named']);
+});
+
+Assert::same(['service:named'], Notes::fetch());
+Assert::type(ArrayObject::class, $container->getService('named'));
+Assert::equal(['named'], $container->getService('named')->getArrayCopy());
+
+ContainerPatcher::of($container)->type(DateTimeImmutable::class, function (Container $container, string $name): object {
+	Notes::add('type:' . $name);
+	Assert::true($container instanceof Container);
+
+	return new DateTimeImmutable('2024-01-01');
+});
+
+Assert::equal(['type:type.a', 'type:type.b'], Notes::fetch());
+Assert::same('2024-01-01', $container->getService('type.a')->format('Y-m-d'));
+Assert::same('2024-01-01', $container->getService('type.b')->format('Y-m-d'));
+
+ContainerPatcher::of($container)->tag('demo.tag', function (Container $container, string $name): object {
+	Notes::add('tag:' . $name);
+	Assert::true($container instanceof Container);
+
+	return new stdClass();
+});
+
+Assert::equal(['tag:tag.one', 'tag:tag.two'], Notes::fetch());
+Assert::type(stdClass::class, $container->getService('tag.one'));
+Assert::type(stdClass::class, $container->getService('tag.two'));
+
+ContainerPatcher::of($container)->serviceInstance('named', new ArrayObject(['direct']));
+Assert::equal(['direct'], $container->getService('named')->getArrayCopy());
+
+Assert::exception(
+	fn (): ContainerPatcher => ContainerPatcher::of($container)->serviceInstance('missing', new ArrayObject()),
+	MissingServiceException::class,
+	'Service named "missing" not found in container.',
+);
+
+Assert::exception(
+	fn (): ContainerPatcher => ContainerPatcher::of($container)->type(SplObjectStorage::class, fn (): object => new SplObjectStorage()),
+	MissingServiceException::class,
+	'Service of type "SplObjectStorage" not found in container.',
+);
+
+Assert::exception(
+	fn (): ContainerPatcher => ContainerPatcher::of($container)->tagInstance('missing.tag', new stdClass()),
+	MissingServiceException::class,
+	'Service tagged "missing.tag" not found in container.',
+);


### PR DESCRIPTION
## Summary
- add `Contributte\Tester\Utils\ContainerPatcher` for replacing already-compiled container services by service name, type, or tag
- support closure factories and direct instance patching via `serviceInstance`, `typeInstance`, and `tagInstance`
- document the new utility in `.docs/README.md` and add `tests/Cases/ContainerPatcher.phpt` coverage including happy paths and missing-service exceptions

## Testing
- `make tests`
- `make phpstan`
- `make cs`