### PR TITLE
Remove phpdbg from coverage target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ tests:
 .PHONY: coverage
 coverage:
 ifdef GITHUB_ACTION
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.xml --coverage-src src tests/Cases
 else
-	vendor/bin/tester -s -p phpdbg --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
+	vendor/bin/tester -s -p php --colors 1 -C --coverage coverage.html --coverage-src src tests/Cases
 endif


### PR DESCRIPTION
## Summary

- replace `-p phpdbg` with `-p php` in the `coverage` target of `Makefile`
- align this repository with the org-wide coverage migration tracked in contributte/contributte#73

## Motivation

`phpdbg` is being removed from Contributte coverage targets in favor of running coverage through the regular PHP binary.

## Changes

- update the GitHub Actions coverage command to use `php`
- update the local HTML coverage command to use `php`

## Testing

- [x] `make coverage` attempted locally
- [ ] Coverage passes locally
- [ ] CI passes

Local `make coverage` currently fails with: `Code coverage functionality requires Xdebug or PCOV extension or PHPDBG SAPI (used php)`.